### PR TITLE
Add documentation for NewEnterpriseClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ func main() {
 }
 ```
 
+If using GitHub Enterprise, use `NewEnterpriseClient` :
+```Go
+client := githubv4.NewEnterpriseClient(os.Getenv("GITHUB_ENDPOINT"), httpClient)
+```
+
 ### Simple Query
 
 To make a query, you need to define a Go type that corresponds to the GitHub GraphQL schema, and contains the fields you're interested in querying. You can look up the GitHub GraphQL schema at https://developer.github.com/v4/query/.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ func main() {
 }
 ```
 
-If you are using GitHub Enterprise, use [`githubv4.NewEnterpriseClient`]`:
+If you are using GitHub Enterprise, use [`githubv4.NewEnterpriseClient`](https://godoc.org/github.com/shurcooL/githubv4#NewEnterpriseClient):
 
 ```Go
 client := githubv4.NewEnterpriseClient(os.Getenv("GITHUB_ENDPOINT"), httpClient)

--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ func main() {
 }
 ```
 
-If using GitHub Enterprise, use `NewEnterpriseClient` :
+If you are using GitHub Enterprise, use [`githubv4.NewEnterpriseClient`]`:
+
 ```Go
 client := githubv4.NewEnterpriseClient(os.Getenv("GITHUB_ENDPOINT"), httpClient)
+// Use client...
 ```
 
 ### Simple Query


### PR DESCRIPTION
adds a simple example how to connect to an enterprise GitHub instance.