### PR TITLE
Allow multiple mutations with inputs in variables

### DIFF
--- a/githubv4.go
+++ b/githubv4.go
@@ -49,7 +49,7 @@ func (c *Client) Query(ctx context.Context, q interface{}, variables map[string]
 func (c *Client) Mutate(ctx context.Context, m interface{}, input Input, variables map[string]interface{}) error {
 	if variables == nil {
 		variables = map[string]interface{}{"input": input}
-	} else {
+	} else if input != nil {
 		variables["input"] = input
 	}
 	return c.client.Mutate(ctx, m, variables)


### PR DESCRIPTION
Closes #70

This PR adds the ability to specify inputs to multiple mutations exclusively in variables, rather than arbitrarily choosing one of them to receive `input`