### PR TITLE
Support marshalling a null URI

### DIFF
--- a/scalar.go
+++ b/scalar.go
@@ -74,6 +74,9 @@ type (
 // MarshalJSON implements the json.Marshaler interface.
 // The URI is a quoted string.
 func (u URI) MarshalJSON() ([]byte, error) {
+	if u.URL == nil {
+		return []byte("null"), nil
+	}
 	return json.Marshal(u.String())
 }
 

--- a/scalar_test.go
+++ b/scalar_test.go
@@ -17,6 +17,11 @@ func TestURI_MarshalJSON(t *testing.T) {
 		want string
 	}{
 		{
+			name: "null",
+			in:   githubv4.URI{},
+			want: `null`,
+		},
+		{
 			in:   githubv4.URI{URL: &url.URL{Scheme: "https", Host: "example.org", Path: "/foo/bar"}},
 			want: `"https://example.org/foo/bar"`,
 		},


### PR DESCRIPTION
Currently, in case trying to marshal a null `URI` struct, it tries to call
`u.String()` function and panics.
The marshal behavior should match the unmarshal behavior and return a
`null` bytes array.

Before changing the `scalar.go` module, the new test scenario of a `nil` URI would panic
<details><summary>Stacktrace (click to expand)</summary>

```text
--- FAIL: TestURI_MarshalJSON (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x5c948a]

goroutine 12 [running]:
testing.tRunner.func1.2(0x6f4160, 0x937ed0)
	/usr/lib/golang/src/testing/testing.go:1143 +0x332
testing.tRunner.func1(0xc00016a600)
	/usr/lib/golang/src/testing/testing.go:1146 +0x4b6
panic(0x6f4160, 0x937ed0)
	/usr/lib/golang/src/runtime/panic.go:965 +0x1b9
encoding/json.(*encodeState).marshal.func1(0xc00005fde8)
	/usr/lib/golang/src/encoding/json/encode.go:328 +0x8d
panic(0x6f4160, 0x937ed0)
	/usr/lib/golang/src/runtime/panic.go:965 +0x1b9
net/url.(*URL).String(0x0, 0xc00005fc28, 0x40d765)
	/usr/lib/golang/src/net/url/url.go:813 +0x4a
github.com/shurcooL/githubv4.URI.MarshalJSON(0x0, 0x734de0, 0x0, 0x7f9358c93a18, 0x0, 0x1)
	/home/yuvalg/work/github/githubv4/scalar.go:80 +0x2f
encoding/json.marshalerEncoder(0xc00014e080, 0x734de0, 0x0, 0x19, 0xc000000100)
	/usr/lib/golang/src/encoding/json/encode.go:479 +0xad
encoding/json.condAddrEncoder.encode(0x760d40, 0x760d98, 0xc00014e080, 0x734de0, 0x0, 0x19, 0x730100)
	/usr/lib/golang/src/encoding/json/encode.go:961 +0xb2
encoding/json.(*encodeState).reflectValue(0xc00014e080, 0x734de0, 0x0, 0x19, 0xc000040100)
	/usr/lib/golang/src/encoding/json/encode.go:360 +0x82
encoding/json.(*encodeState).marshal(0xc00014e080, 0x734de0, 0x0, 0xc000150100, 0x0, 0x0)
	/usr/lib/golang/src/encoding/json/encode.go:332 +0xf9
encoding/json.Marshal(0x734de0, 0x0, 0x7ed6e5, 0x26, 0x438, 0x4f4f60, 0x8cc078)
	/usr/lib/golang/src/encoding/json/encode.go:161 +0x52
github.com/shurcooL/githubv4_test.TestURI_MarshalJSON(0xc00016a600)
	/home/yuvalg/work/github/githubv4/scalar_test.go:30 +0x158
testing.tRunner(0xc00016a600, 0x760f98)
	/usr/lib/golang/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/lib/golang/src/testing/testing.go:1238 +0x2b3
FAIL	github.com/shurcooL/githubv4	0.005s
?   	github.com/shurcooL/githubv4/example/githubv4dev	[no test files]

=== Failed
=== FAIL: . TestURI_MarshalJSON (0.00s)
```
</details>